### PR TITLE
- Propose fix for pod error.

### DIFF
--- a/lib/Test/StructuredObject/CodeStub.pm
+++ b/lib/Test/StructuredObject/CodeStub.pm
@@ -26,7 +26,7 @@ sub _label {
 
 =method C<dcode>
 
-Return the source-code of this objects C<coderef> using L< B::Deparse|B::Deparse >.
+Return the source-code of this objects C<coderef> using L<B::Deparse>.
 Will not work on the base class as it needs C<< ->code >> to work.
 
 =cut


### PR DESCRIPTION
Hi @KENTL,

Please review the proposed fix to the pod error as below:

```
     #   Failed test 'POD test for blib/lib/Test/StructuredObject/CodeStub.pm'
     #   at /usr/local/share/perl/5.18.2/Test/Pod.pm line 187.
     # blib/lib/Test/StructuredObject/CodeStub.pm (106): L<> starts or ends with whitespace
     # Looks like you failed 1 test of 6.
     xt/author/pod-syntax.t .... Dubious, test returned 1 (wstat 256, 0x100) 
```

Many Thanks.
Best Regards,
Mohammad S Anwar
